### PR TITLE
Init thread libraries for cmake.

### DIFF
--- a/nheqminer/CMakeLists.txt
+++ b/nheqminer/CMakeLists.txt
@@ -124,4 +124,4 @@ set(LIBS ${LIBS} ${Threads_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 #target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
-target_link_libraries(${PROJECT_NAME} ${LIBS})
+target_link_libraries(${PROJECT_NAME} ${LIBS} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
On linux linking pthread fails with:

```
[100%] Linking CXX executable nheqminer                                        
/usr/bin/ld: CMakeFiles/nheqminer.dir/main.cpp.o: undefined reference to symbol 'pthread_rwlock_wrlock@@GLIBC_2.2.5'                                          
/usr/lib/libpthread.so.0: error adding symbols: DSO missing from command line  collect2: error: ld returned 1 exit status                                     
make[2]: *** [CMakeFiles/nheqminer.dir/build.make:494: nheqminer] Error 1      
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/nheqminer.dir/all] Error 2   
make: *** [Makefile:84: all] Error 2
```

This is the fix. [Source](http://stackoverflow.com/a/32711747/1260906).
