### PR TITLE
Changes the Ubuntu 14.04 dependancy libboost-all-dev to libboost-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Working solvers CPU_TROMP, CPU_XENONCAT, CUDA_TROMP, OCL_XMP, OCL_SILENTARMY
 ## Linux (Ubuntu 14.04 / 16.04) Build CPU_XENONCAT:
 
  - Open terminal and run the following commands:
-   - `sudo apt-get install cmake build-essential libboost-all-dev`
+   - `sudo apt-get install cmake build-essential libboost-dev`
    - `git clone -b Linux https://github.com/nicehash/nheqminer.git`
    - `cd nheqminer/cpu_xenoncat/Linux/asm/`
    - `sh assemble.sh`
@@ -58,7 +58,7 @@ Working solvers CPU_TROMP, CPU_XENONCAT, CUDA_TROMP, OCL_XMP, OCL_SILENTARMY
    - and make sure you have the [AMD drivers](http://support.amd.com/en-us/download) installed
    - install them to the default paths
    - `sudo apt-get install mesa-common-dev`
-   - `sudo apt-get install cmake build-essential libboost-all-dev`
+   - `sudo apt-get install cmake build-essential libboost-dev`
    - `git clone -b Linux https://github.com/nicehash/nheqminer.git`
    - `cd nheqminer/Linux_cmake/nheqminer_AMD && cmake . -DOPENCL_LIBRARY=/usr/lib/x86_64-linux-gnu/libOpenCL.so -DOPENCL_INCLUDE_DIRECTORY=/opt/AMDAPPSDK-3.0/include && make -j $(nproc)`
    - `cp ../../3rdparty/amd_bins_linux/* -r .`


### PR DESCRIPTION
This fixes an issue when following the instruction to install
dependencies for Ubuntu 14.04, this issue did not effect version
16.04.  However the fix for 14.04 works just as well for 16.04,
outlined at this ask Ubuntu thread;
http://askubuntu.com/questions/670924/how-to-install-boost-on-ubuntu-14-04

The issue it fixes has an example here http://pastebin.com/AAgvYSbQ
blocking the install of libboost1.54 development files.

This fix was tested on 16.04 and 14.04 both of which installed
the dependencies need for the nheqminer.