### PR TITLE
Cuda 9+ compile support

### DIFF
--- a/cuda_djezo/CMakeLists.txt
+++ b/cuda_djezo/CMakeLists.txt
@@ -21,7 +21,7 @@ FIND_PACKAGE(CUDA REQUIRED)
 if(COMPUTE AND (COMPUTE GREATER 0))
         LIST(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_${COMPUTE},code=sm_${COMPUTE})
 else(COMPUTE AND (COMPUTE GREATER 0))
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode arch=compute_50,code=sm_50; -gencode arch=compute_52,code=sm_52; -gencode arch=compute_60,code=sm_60 )
+        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode arch=compute_50,code=sm_50;-gencode arch=compute_52,code=sm_52; -gencode arch=compute_60,code=sm_60, -gencode arch=compute_70,code=sm_70;)
 endif(COMPUTE AND (COMPUTE GREATER 0))
 
 if(CUDA_FOUND)

--- a/cuda_djezo/CMakeLists.txt
+++ b/cuda_djezo/CMakeLists.txt
@@ -15,7 +15,7 @@ file(GLOB HEADERS
     )
 
 
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-D_FORCE_INLINES;--disable-warnings;--ptxas-options=-v;-Xptxas=-dlcm=ca;-Xptxas=-dscm=cs; -O3)
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-D_FORCE_INLINES;--disable-warnings;--ptxas-options=-v;-Xptxas=-dlcm=ca;-Xptxas=-dscm=cs; -O3; --allow-expensive-optimizations=02;-O=3)
 
 FIND_PACKAGE(CUDA REQUIRED)
 if(COMPUTE AND (COMPUTE GREATER 0))

--- a/cuda_djezo/eqcuda.hpp
+++ b/cuda_djezo/eqcuda.hpp
@@ -3,7 +3,6 @@
 #include "cuda.h"
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
-#include "device_functions_decls.h"
 #include "../cpu_tromp/blake2/blake2.h"
 #include "cuda_djezo.hpp"
 


### PR DESCRIPTION
It will build and run with CUDA9 even though it's not officially supported. You will have to modify one file though, remove the device_functions_decls.h header include from all files in the project. See tpruvot/ccminer#25 for more information.